### PR TITLE
Revert "Change install dir to /usr/sbin"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -86,5 +86,4 @@ executable(
         dependency('openssl'),
     ],
     install: true,
-    install_dir: get_option('sbindir'),
 )

--- a/src/tracer.hpp
+++ b/src/tracer.hpp
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <unistd.h>
-
 #include <cstdio>
 #include <cstring>
 
@@ -49,7 +47,7 @@ struct Tracer
      */
     void done()
     {
-        complete(" OK ", COLOR_GREEN);
+        complete(" OK ");
     }
 
     /**
@@ -57,7 +55,7 @@ struct Tracer
      */
     void fail()
     {
-        complete("FAIL", COLOR_RED);
+        complete("FAIL");
     }
 
     ~Tracer()
@@ -70,28 +68,14 @@ struct Tracer
 
   private:
     /**
-     * @return True if terminal is interactive.
-     */
-    bool is_tty() const
-    {
-        static const bool tty = isatty(fileno(stdout));
-        return tty;
-    }
-
-    /**
      * @brief Complete trace and print status
      */
-    void complete(const char* status, const char* color)
+    void complete(const char* status)
     {
-        fprintf(stdout, "[%s%s%s]\n", is_tty() ? color : "", status,
-                is_tty() ? COLOR_DEFAULT : "");
+        fprintf(stdout, "[%s]\n", status);
         fflush(stdout);
         completed = true;
     }
 
     bool completed = false;
-
-    static constexpr auto COLOR_RED = "\033[31;1m";
-    static constexpr auto COLOR_GREEN = "\033[32m";
-    static constexpr auto COLOR_DEFAULT = "\033[0m";
 };


### PR DESCRIPTION
OpenBMC executables should be installed in /usr/bin, references:
https://github.com/openbmc/docs/blob/master/anti-patterns.md#placement-of-applications-in-sbin-or-usrsbin

This reverts commit bdad12ea2b564cba632715367ce9788ec05787ea.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>