### PR TITLE
Allow any compression method

### DIFF
--- a/src/fwupdate.cpp
+++ b/src/fwupdate.cpp
@@ -153,7 +153,7 @@ void FwUpdate::unpack(const fs::path& path)
         Tracer tracer("Unpack firmware package");
 
         std::ignore =
-            exec("tar -xzf %s -C %s 2>/dev/null", path.c_str(), tmpdir.c_str());
+            exec("tar -xf %s -C %s 2>/dev/null", path.c_str(), tmpdir.c_str());
 
         for (const auto& it : fs::directory_iterator(tmpdir))
         {


### PR DESCRIPTION
Previous implementation supported only gzipped bundles.
This commit allows to use the bundles compressed by any method supported
by tar. The uncompressed bundles are also allowed now.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>