### PR TITLE
Add more clear message about machine mismatch

### DIFF
--- a/src/fwupdate.cpp
+++ b/src/fwupdate.cpp
@@ -271,8 +271,11 @@ void FwUpdate::checkMachineType()
         auto targetMachine = getCfgValue(manifestFile, "MachineName");
         if (currentMachine != targetMachine)
         {
-            throw FwupdateError("Frimware package is not compatible with this "
-                                "system.");
+            throw FwupdateError(
+                "Firmware package is not compatible with this system.\n"
+                "Expected target machine type :  %s\n"
+                "Actual target machine type   :  %s\n",
+                targetMachine.c_str(), currentMachine.c_str());
         }
 
         tracer.done();


### PR DESCRIPTION
This replaces the message about machine mismatch.
The message will now contain the system and bundle machine types.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>