### PR TITLE
reboot-guard: Fix misspelling

### DIFF
--- a/src/fwupdate.cpp
+++ b/src/fwupdate.cpp
@@ -140,7 +140,7 @@ void FwUpdate::unlock()
 #ifdef REBOOT_GUARD_SUPPORT
     if (locked)
     {
-        Tracer tracer("Unocking BMC reboot");
+        Tracer tracer("Unlocking BMC reboot");
         startUnit(REBOOT_GUARD_DISABLE);
         locked = false;
         tracer.done();


### PR DESCRIPTION
This fixes a misspelling in the "Unlocking BMC reboot" message.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>