### PR TITLE
make binary paths configurable in compile time

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,15 @@ if openpower_support
     ]
 endif
 
+conf.set_quoted('TAR_CMD', get_option('tar-cmd'))
+conf.set_quoted('REBOOT_CMD', get_option('reboot-cmd'))
+conf.set_quoted('FW_SETENV_CMD', get_option('fw-setenv-cmd'))
+conf.set_quoted('FW_PRINTENV_CMD', get_option('fw-printenv-cmd'))
+conf.set_quoted('FLASHCP_CMD', get_option('flashcp-cmd'))
+conf.set_quoted('FLASH_ERASE_CMD', get_option('flash-erase-cmd'))
+conf.set_quoted('NANDDUMP_CMD', get_option('nanddump-cmd'))
+conf.set_quoted('NANDWRITE_CMD', get_option('nandwrite-cmd'))
+
 conf.set_quoted('OS_RELEASE_FILE', get_option('os-release-file'))
 conf.set_quoted('MANIFEST_FILE_NAME', get_option('manifest-file-name'))
 conf.set_quoted('PUBLICKEY_FILE_NAME', get_option('publickey-file-name'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -55,8 +55,6 @@ option('hiomapd-iface', type: 'string',
        value: 'xyz.openbmc_project.Hiomapd.Control',
        description: 'The hiomapd control interface.')
 
-option('pflash-cmd', type: 'string', value: 'pflash',
-       description: 'command line tool to manipulate PNOR flash')
 option('pnor-file-ext', type: 'string', value: '.pnor',
        description: 'The extension of the PNOR firmware image file.')
 
@@ -90,3 +88,23 @@ option('openbmc-flash-path', type: 'string', value: '/run/initramfs',
        description: 'The path where from the OpenBMC image will be flashed.')
 option('openbmc-whitelist-file-name', type: 'string', value: 'whitelist',
        description: 'The OpenBMC whilte file name.')
+
+option('tar-cmd', type: 'string', value: '/bin/tar',
+       description: 'command line tool to work with TAR archieve')
+option('reboot-cmd', type: 'string', value: '/sbin/reboot',
+       description: 'command line tool to reboot system')
+option('fw-setenv-cmd', type: 'string', value: '/sbin/fw_setenv',
+       description: 'command line tool to update u-boot variables')
+option('fw-printenv-cmd', type: 'string', value: '/sbin/fw_printenv',
+       description: 'command line tool to read u-boot variables')
+
+option('flashcp-cmd', type: 'string', value: '/usr/sbin/flashcp',
+       description: 'command line tool to write flash')
+option('flash-erase-cmd', type: 'string', value: '/usr/sbin/flash_erase',
+       description: 'command line tool to erase flash')
+option('nanddump-cmd', type: 'string', value: '/usr/sbin/nanddump',
+       description: 'command line tool to dump NAND MTD partition')
+option('nandwrite-cmd', type: 'string', value: '/usr/sbin/nandwrite',
+       description: 'command line tool to write NAND MTD partition')
+option('pflash-cmd', type: 'string', value: '/usr/sbin/pflash',
+       description: 'command line tool to manipulate PNOR flash')

--- a/src/fwupdate.cpp
+++ b/src/fwupdate.cpp
@@ -185,7 +185,7 @@ void FwUpdate::unpack(const fs::path& path)
         Tracer tracer("Unpack firmware package");
 
         std::ignore =
-            exec("tar -xf %s -C %s 2>/dev/null", path.c_str(), tmpdir.c_str());
+            exec(TAR_CMD " -xf %s -C %s 2>/dev/null", path.c_str(), tmpdir.c_str());
 
         for (const auto& it : fs::directory_iterator(tmpdir))
         {

--- a/src/image_bios.cpp
+++ b/src/image_bios.cpp
@@ -206,7 +206,7 @@ void BIOSUpdater::doInstall(const fs::path& file)
     //       progress from original flashcp output.
     printf("Writing %s to %s\n", file.filename().c_str(), mtdDevice);
     int rc =
-        system(strfmt("flashcp -v %s %s", file.c_str(), mtdDevice).c_str());
+        system(strfmt(FLASHCP_CMD " -v %s %s", file.c_str(), mtdDevice).c_str());
     checkWaitStatus(rc, "");
 }
 
@@ -217,7 +217,7 @@ void BIOSUpdater::doBeforeInstall(bool reset)
         puts("Preserving UEFI settings...");
         const fs::path dumpFile(tmpdir / nvramFile);
         const std::string cmd =
-            strfmt("nanddump --startaddress %lu --length %lu --file '%s' %s",
+            strfmt(NANDDUMP_CMD " --startaddress %lu --length %lu --file '%s' %s",
                    nvramOffset, nvramSize, dumpFile.c_str(), mtdDevice);
         const int rc = system(cmd.c_str());
         checkWaitStatus(rc, std::string());
@@ -240,14 +240,14 @@ bool BIOSUpdater::doAfterInstall(bool reset)
 
         puts("Preparing NVRAM partition...");
         const std::string cmdErase =
-            strfmt("flash_erase %s %lu %lu", mtdDevice, nvramOffset,
+            strfmt(FLASH_ERASE_CMD " %s %lu %lu", mtdDevice, nvramOffset,
                    nvramSize / mtdBlockSize);
         int rc = system(cmdErase.c_str());
         checkWaitStatus(rc, std::string());
 
         puts("Restoring UEFI settings...");
         const std::string cmdWrite =
-            strfmt("nandwrite --start %lu %s %s", nvramOffset, mtdDevice,
+            strfmt(NANDWRITE_CMD " --start %lu %s %s", nvramOffset, mtdDevice,
                    dumpFile.c_str());
         rc = system(cmdWrite.c_str());
         checkWaitStatus(rc, std::string());

--- a/src/image_intel.cpp
+++ b/src/image_intel.cpp
@@ -27,7 +27,7 @@ static size_t getBootAddress()
 {
     const std::string bootcmdPrefix = "bootcmd=bootm";
 
-    std::string bootcmd = exec("fw_printenv bootcmd");
+    std::string bootcmd = exec(FW_PRINTENV_CMD " bootcmd");
     if (bootcmd.compare(0, bootcmdPrefix.length(), bootcmdPrefix) == 0)
     {
         return std::stoul(bootcmd.substr(bootcmdPrefix.length()), nullptr, 16);
@@ -41,7 +41,7 @@ static size_t getBootAddress()
  */
 static void setBootAddress(size_t address)
 {
-    std::ignore = exec("fw_setenv bootcmd bootm %08x", address);
+    std::ignore = exec(FW_SETENV_CMD " bootcmd bootm %08x", address);
 }
 
 using FileSystem = std::string;
@@ -149,9 +149,9 @@ void IntelPlatformsUpdater::reset()
     releaseFlashDrive();
 
     Tracer tracer("Clear writable partitions");
-    std::ignore = exec("flash_erase /dev/mtd/rwfs 0 0");
-    std::ignore = exec("flash_erase /dev/mtd/sofs 0 0");
-    std::ignore = exec("flash_erase /dev/mtd/u-boot-env 0 0");
+    std::ignore = exec(FLASH_ERASE_CMD " /dev/mtd/rwfs 0 0");
+    std::ignore = exec(FLASH_ERASE_CMD " /dev/mtd/sofs 0 0");
+    std::ignore = exec(FLASH_ERASE_CMD " /dev/mtd/u-boot-env 0 0");
 
     if (bootaddr == IMAGE_B_ADDR)
     {
@@ -208,7 +208,7 @@ void IntelPlatformsUpdater::doInstall(const fs::path& file)
         // NOTE: This process may take a lot of time and we want to show the
         //       progress from original flashcp output.
         printf("Writing %s to %s\n", filename.c_str(), mtd);
-        int rc = system(strfmt("flashcp -v %s %s", file.c_str(), mtd).c_str());
+        int rc = system(strfmt(FLASHCP_CMD " -v %s %s", file.c_str(), mtd).c_str());
         checkWaitStatus(rc, "");
     }
     else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,7 +97,7 @@ void reboot(bool interactive)
         if (!manualReboot)
         {
             Tracer tracer("Reboot BMC system");
-            std::ignore = exec("/sbin/reboot");
+            std::ignore = exec(REBOOT_CMD);
             tracer.done();
         }
     }


### PR DESCRIPTION
Use absolute paths for all binaries called from fwupdate. This solves
issue with incomplete PATH environment variable when calling fwupdate
from ssh command.
Now user can use ssh command without tricks:
ssh <user@host> fwupdate -yf /tmp/image-update

Signed-off-by: Andrei Kartashev <a.kartashev@yadro.com>