### PR TITLE
skip unusable updaters

### DIFF
--- a/src/fwupdbase.cpp
+++ b/src/fwupdbase.cpp
@@ -39,6 +39,12 @@ void FwUpdBase::verify(const fs::path& publicKey, const std::string& hashFunc)
 
 bool FwUpdBase::install(bool reset)
 {
+    if (files.empty())
+    {
+        // Nothing to install for this updater type.
+        return false;
+    }
+
     doBeforeInstall(reset);
 
     for (const auto& file : files)


### PR DESCRIPTION
During update some implementations should be skipped if there are no
files for them.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>