### PR TITLE
vegman/bios: hack for PCA9698 on Vegman rev-E.

### DIFF
--- a/src/image_bios.hpp
+++ b/src/image_bios.hpp
@@ -29,4 +29,5 @@ struct BIOSUpdater : public FwUpdBase
     bool locked = false;
     gpiod::line gpioPCHPower;
     gpiod::line gpioBIOSSel;
+    int pca9698FD = -1;
 };


### PR DESCRIPTION
Vegman Rev-E has an additional guard in the PCH power management chain
that prevents to change GPIO levels until the OEPOL bit in the Mode
register is set to 1. But this register is unmanageable by the kernel
driver.

This commit brings a solution that uses i2c bus to communicate with the
GPIO expander and set the required bit when it needs.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>