### PR TITLE
image_intel: suppress warning on reset

### DIFF
--- a/src/image_intel.cpp
+++ b/src/image_intel.cpp
@@ -27,7 +27,7 @@ static size_t getBootAddress()
 {
     const std::string bootcmdPrefix = "bootcmd=bootm";
 
-    std::string bootcmd = exec(FW_PRINTENV_CMD " bootcmd");
+    std::string bootcmd = exec(FW_PRINTENV_CMD " bootcmd 2>/dev/null");
     if (bootcmd.compare(0, bootcmdPrefix.length(), bootcmdPrefix) == 0)
     {
         return std::stoul(bootcmd.substr(bootcmdPrefix.length()), nullptr, 16);
@@ -41,7 +41,8 @@ static size_t getBootAddress()
  */
 static void setBootAddress(size_t address)
 {
-    std::ignore = exec(FW_SETENV_CMD " bootcmd bootm %08x", address);
+    std::ignore =
+        exec(FW_SETENV_CMD " bootcmd bootm %08x 2>/dev/null", address);
 }
 
 using FileSystem = std::string;


### PR DESCRIPTION
During resetting Intel-based hardware this tool shows a warning
about bad CRC. That happens due to writing into a cleaned partition,
and is not an error.

This commit brings `stderr` redirection into the `fw_setenv/fw_printenv`
calls to suppress such warnings.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>