### PR TITLE
Hide tool from unprivileged user

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -112,4 +112,5 @@ executable(
     fwupdate_sources,
     dependencies: fwupdate_dependencies,
     install: true,
+    install_dir: get_option('sbindir'),
 )


### PR DESCRIPTION
The unprivileged users cannot call this tool directly.
This commit moves it to the `/usr/sbin` directory.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>