### PR TITLE
Preserve GBE region during BIOS update

### DIFF
--- a/src/image_bios.hpp
+++ b/src/image_bios.hpp
@@ -25,6 +25,10 @@ struct BIOSUpdater : public FwUpdBase
     bool doAfterInstall(bool reset) override;
     bool isFileFlashable(const fs::path& file) const override;
 
+    static bool writeGbeOnly;
+    static void readNvram(const std::string& file);
+    static void writeNvram(const std::string& file);
+
   private:
     bool locked = false;
     gpiod::line gpioPCHPower;


### PR DESCRIPTION
Allows to save the settings of network adapters (e.g. MAC address).

Signed-off-by: Artem Senichev <a.senichev@yadro.com>