### PR TITLE
bios-update:after-install: Reset bios_active to NA

### DIFF
--- a/src/fwupdbase.hpp
+++ b/src/fwupdbase.hpp
@@ -57,6 +57,14 @@ struct FwUpdBase : public FwUpdIFace
      */
     virtual bool doAfterInstall(bool /*reset*/) = 0;
 
+    /** @brief Update an obsolete version in dbus for some version activation
+     * is required to avoid providing nonactual value.
+     *
+     * @param objectPath the DBus object path of firmware version.
+     * @param version the Version string value.
+     */
+    void updateDBusStoredVersion(const std::string&, const std::string&);
+
     Files files;     //! List of firmware files
     fs::path tmpdir; //! Temporary directory
 };

--- a/src/image_bios.cpp
+++ b/src/image_bios.cpp
@@ -442,6 +442,9 @@ bool BIOSUpdater::doAfterInstall(bool reset)
     const int rc = system(cmd.c_str());
     checkWaitStatus(rc, std::string());
 
+    // reset BIOS version for bios_active ID
+    updateDBusStoredVersion("/xyz/openbmc_project/software/bios_active", "N/A");
+
     return false; // reboot is not needed
 }
 


### PR DESCRIPTION
After BIOS update need reset bios_active dbus-object to 'N/A', to avoid
represent obsolete firmware version.

End-user-impact: After successfully updating bios, the stored version
                 will be reset to N/A until the host is powered on.

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>