### PR TITLE
split machine type and signature checks

### DIFF
--- a/src/fwupdate.cpp
+++ b/src/fwupdate.cpp
@@ -287,7 +287,6 @@ void FwUpdate::checkMachineType()
 void FwUpdate::verify()
 {
     systemLevelVerify();
-    checkMachineType();
 
     auto publicKeyFile = getFWFile(PUBLICKEY_FILE_NAME);
     auto manifestFile = getFWFile(MANIFEST_FILE_NAME);

--- a/src/fwupdate.hpp
+++ b/src/fwupdate.hpp
@@ -45,6 +45,11 @@ struct FwUpdate
     void verify();
 
     /**
+     * @brief Compare system and package machine types.
+     */
+    void checkMachineType();
+
+    /**
      * @brief Install firmware
      *
      * @param reset - flag to skip restore of the settings
@@ -82,11 +87,6 @@ struct FwUpdate
      *        and hash on the system.
      */
     void systemLevelVerify();
-
-    /**
-     * @brief Compare system and package machine types.
-     */
-    void checkMachineType();
 
   private:
     fs::path tmpdir;


### PR DESCRIPTION
This commit makes the machine type checking as a standalone procedure
that may be disabled by `-m/--no-machine-type` command line key.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>