### PR TITLE
vegman: Save/restore MAC addresses of x722

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,7 @@ elif bmc_image_type == 'intel-platforms'
     fwupdate_sources += [
         'src/image_intel.cpp',
         'src/image_bios.cpp',
+        'src/nvm_x722.cpp',
     ]
     fwupdate_dependencies += [
         dependency('libgpiodcxx'),

--- a/src/nvm_x722.cpp
+++ b/src/nvm_x722.cpp
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 YADRO
+
+#include "nvm_x722.hpp"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <system_error>
+
+NvmX722::NvmX722(const std::filesystem::path& file)
+{
+    int fd = -1;
+    data = MAP_FAILED;
+
+    try
+    {
+        // open file
+        fd = open(file.c_str(), O_RDWR);
+        if (fd == -1)
+        {
+            throw std::system_error(errno, std::generic_category());
+        }
+
+        // get file size
+        struct stat st;
+        if (fstat(fd, &st) == -1)
+        {
+            throw std::system_error(errno, std::generic_category());
+        }
+        size = st.st_size;
+
+        // map file to memory
+        data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        if (data == MAP_FAILED)
+        {
+            throw std::system_error(errno, std::generic_category());
+        }
+
+        // check min size
+        if (size < nvmSize)
+        {
+            throw std::runtime_error("The image file is too small to contain a 10GBE region");
+        }
+
+        // move start offset if input file is a BIOS image
+        start = (size == nvmSize) ? 0 : nvmOffset;
+
+        // search for valid bank
+        if (readWord(controlWord) != bankValid)
+        {
+            start += bankSize;
+            if (readWord(controlWord) != bankValid)
+            {
+                throw std::runtime_error("No valid bank in 10GBE");
+            }
+        }
+    }
+    catch (...)
+    {
+        if (fd != -1)
+        {
+            close(fd);
+        }
+        if (data != MAP_FAILED)
+        {
+            munmap(data, size);
+        }
+        throw;
+    }
+
+    close(fd);
+}
+
+NvmX722::~NvmX722()
+{
+    munmap(data, size);
+}
+
+NvmX722::MacAddresses NvmX722::getMac() const
+{
+    MacAddresses mac;
+
+    // get offset for MAC settings
+    word_t offset = readWord(magicOffset1);
+    offset += magicOffset2;
+    offset += readWord(offset);
+
+    // read PF MAC addresses
+    for (size_t i = 0; i < mac.size(); ++i)
+    {
+        offset += macHeaderSize;
+        const uint8_t* macPtr = wordPtr(offset, sizeof(mac_t));
+        std::copy(macPtr, macPtr + sizeof(mac_t), mac[i]);
+        offset += sizeof(mac_t) / sizeof(word_t);
+    }
+
+    return mac;
+}
+
+void NvmX722::setMac(const MacAddresses& mac)
+{
+    // get offset for MAC settings
+    word_t offset = readWord(magicOffset1);
+    offset += magicOffset2;
+    offset += readWord(offset);
+
+    // write PF MAC addresses
+    for (size_t i = 0; i < mac.size(); ++i)
+    {
+        offset += macHeaderSize;
+        uint8_t* macPtr = wordPtr(offset, sizeof(mac_t));
+        std::copy(mac[i], mac[i] + sizeof(mac_t), macPtr);
+        offset += sizeof(mac_t) / sizeof(word_t);
+    }
+
+    // update checksum
+    uint8_t* chkSumPtr = wordPtr(checksumOffset, sizeof(word_t));
+    *reinterpret_cast<word_t*>(chkSumPtr) = calcChecksum();
+
+    // write changes to persistent storage
+    if (msync(data, size, MS_SYNC) == -1)
+    {
+        throw std::system_error(errno, std::generic_category());
+    }
+}
+
+uint8_t* NvmX722::wordPtr(word_t offset, size_t maxSize) const
+{
+    const size_t byteOffset = start + offset * sizeof(word_t);
+    if (byteOffset + maxSize > size)
+    {
+        throw std::runtime_error("Invalid 10GBE NVM");
+    }
+    return reinterpret_cast<uint8_t*>(data) + byteOffset;
+}
+
+NvmX722::word_t NvmX722::readWord(word_t offset) const
+{
+    const uint8_t* ptr = wordPtr(offset, sizeof(word_t));
+    return *reinterpret_cast<const word_t*>(ptr);
+}
+
+NvmX722::word_t NvmX722::calcChecksum() const
+{
+    word_t chkSum = 0;
+    const word_t vpdStart = readWord(vpdOffset);
+
+    for (word_t i = 0; i < bankSize / sizeof(word_t); ++i)
+    {
+        if (i == checksumOffset)
+        {
+            continue; // skip checksum word
+        }
+        if (i >= vpdStart && i < vpdStart + vpdSize / sizeof(word_t))
+        {
+            continue; // skip VPD module
+        }
+        if (i >= (bankSize - pcieAltSize) / sizeof(word_t))
+        {
+            break; // skip PCIe ALT module (it resides at the end of bank)
+        }
+        chkSum += readWord(i);
+    }
+
+    return checksumBase - chkSum;
+}

--- a/src/nvm_x722.hpp
+++ b/src/nvm_x722.hpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 YADRO
+
+#include <array>
+#include <filesystem>
+
+/** @brief Read and write NVM for x722. */
+class NvmX722
+{
+  public:
+    using word_t = uint16_t;
+    using mac_t = uint8_t[6]; // MAC address: 48 bits
+
+    // Number of MAC addresses in the NVM image
+    static constexpr size_t maxMac = 4;
+
+    using MacAddresses = std::array<mac_t, maxMac>;
+
+    // Offset of the 10GBE region inside the BIOS image
+    static constexpr size_t nvmOffset = 0x00a36000;
+    // Size of the 10GBE NVM image
+    static constexpr size_t nvmSize = 0x005ba000;
+
+    // Magic constants from the Intel's guide,
+    // see "Intel® Ethernet Connection X722 - Programming MAC Addresses"
+    static constexpr word_t controlWord = 0x0000;
+    static constexpr word_t bankValid = 0x0249;
+    static constexpr size_t bankSize = 0x10000;
+    static constexpr word_t magicOffset1 = 0x0048;
+    static constexpr word_t magicOffset2 = 0x0018;
+    static constexpr word_t macHeaderSize = 0x0001;
+    static constexpr word_t checksumOffset = 0x003f;
+    static constexpr word_t checksumBase = 0xbaba;
+    static constexpr word_t vpdOffset = 0x002f;
+    static constexpr size_t vpdSize = 1024;
+    static constexpr size_t pcieAltSize = 1024;
+
+    /**
+     * @brief Constructor: open file.
+     *
+     * @param[in] file Path to the file to load (10GBE or BIOS image)
+     *
+     * @throw std::exception in case of errors
+     */
+    NvmX722(const std::filesystem::path& file);
+
+    /** @brief Destructor. */
+    ~NvmX722();
+
+    /**
+     * @brief Get list of PF MAC addresses.
+     *
+     * @return list of MAC addresses
+     *
+     * @throw std::exception in case of errors
+     */
+    MacAddresses getMac() const;
+
+    /**
+     * @brief Set PF MAC addresses.
+     *
+     * @param[in] mac list of MAC addresses
+     *
+     * @throw std::exception in case of errors
+     */
+    void setMac(const MacAddresses& mac);
+
+  private:
+    /**
+     * @brief Get data pointer for specified word offset.
+     *
+     * @param[in] offset word offset
+     * @param[in] maxSize number of bytes that are needed at specified offset
+     *
+     * @return pointer to the data at specified word offset
+     *
+     * @throw std::exception in case of errors
+     */
+    uint8_t* wordPtr(word_t offset, size_t maxSize) const;
+
+    /**
+     * @brief Read word at specified word offset.
+     *
+     * @param[in] offset word offset
+     *
+     * @return word value
+     */
+    word_t readWord(word_t offset) const;
+
+    /**
+     * @brief Calculate checksum for current block.
+     *
+     * @return checksum
+     */
+    word_t calcChecksum() const;
+
+  private:
+    void* data;   ///< Pointer to the file data
+    size_t size;  ///< Size of file data in bytes
+    size_t start; ///< Offset to the valid block of NVM
+};


### PR DESCRIPTION
Allows to update BIOS image including the 10GBE region without loosing
MAC addresses.
Implementation based on "Intel® Ethernet Connection X722 - Programming
MAC Addresses" document.

Signed-off-by: Artem Senichev <a.senichev@yadro.com>