### PR TITLE
Add tar errors output

### DIFF
--- a/src/fwupdate.cpp
+++ b/src/fwupdate.cpp
@@ -190,7 +190,7 @@ void FwUpdate::unpack(const fs::path& path)
         Tracer tracer("Unpack firmware package");
 
         std::ignore =
-            exec(TAR_CMD " -xf %s -C %s 2>/dev/null", path.c_str(), tmpdir.c_str());
+            exec(TAR_CMD " -xf %s -C %s 2>&1", path.c_str(), tmpdir.c_str());
 
         for (const auto& it : fs::directory_iterator(tmpdir))
         {


### PR DESCRIPTION
Unpack procedure failures output is unuseful:
```
Unpack firmware package ...               [FAIL]
exited with status 1. Output:
```

This adds output error messages from `tar` command and improves UI.
It will now look like:
```
Unpack firmware package ...               [FAIL]
exited with status 1. Output:
tar: write error: No space left on device
```

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>