### PR TITLE
Make bios updater optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,10 +55,9 @@ if reboot_guard_support
     conf.set_quoted('REBOOT_GUARD_DISABLE', get_option('reboot-guard-disable'))
 endif
 
-openpower_support = get_option('openpower-support')
-conf.set('OPENPOWER_SUPPORT', openpower_support)
-
-if openpower_support
+host_image_type = get_option('host-image-type')
+if host_image_type == 'openpower'
+    conf.set('OPENPOWER_SUPPORT', true)
     conf.set_quoted('HIOMAPD_PATH', get_option('hiomapd-path'))
     conf.set_quoted('HIOMAPD_IFACE', get_option('hiomapd-iface'))
     conf.set_quoted('PFLASH_CMD', get_option('pflash-cmd'))
@@ -66,6 +65,16 @@ if openpower_support
 
     fwupdate_sources += [
         'src/image_openpower.cpp',
+    ]
+elif host_image_type == 'intel-c62x'
+    conf.set('INTEL_C62X_SUPPORT', true)
+
+    fwupdate_sources += [
+        'src/image_bios.cpp',
+        'src/nvm_x722.cpp',
+    ]
+    fwupdate_dependencies += [
+        dependency('libgpiodcxx'),
     ]
 endif
 
@@ -98,11 +107,6 @@ elif bmc_image_type == 'intel-platforms'
     conf.set('INTEL_PLATFORMS', true)
     fwupdate_sources += [
         'src/image_intel.cpp',
-        'src/image_bios.cpp',
-        'src/nvm_x722.cpp',
-    ]
-    fwupdate_dependencies += [
-        dependency('libgpiodcxx'),
     ]
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -35,8 +35,9 @@ option('reboot-guard-disable', type: 'string',
        value: 'reboot-guard-disable.service',
        description: 'The systemd service to unlock the BMC rebooting')
 
-option('openpower-support', type: 'boolean', value: false,
-       description: 'Enable support for OpenPOWER firmwares')
+option('host-image-type', type: 'combo',
+       choices: [ 'openpower', 'intel-c62x', 'none' ],
+       description: 'The Host firmware image type')
 
 option('chassis-state-path', type: 'string',
        value: '/xyz/openbmc_project/state/chassis0',

--- a/src/fwupdate.cpp
+++ b/src/fwupdate.cpp
@@ -18,8 +18,11 @@
 #endif
 
 #ifdef INTEL_PLATFORMS
-#include "image_bios.hpp"
 #include "image_intel.hpp"
+#endif
+
+#ifdef INTEL_C62X_SUPPORT
+#include "image_bios.hpp"
 #endif
 
 #ifdef OPENPOWER_SUPPORT
@@ -91,11 +94,13 @@ FwUpdate::FwUpdate(bool force) : tmpdir(createTmpDir()), force(force)
 #ifdef OPENPOWER_SUPPORT
     updaters.emplace_back(std::make_unique<OpenPowerUpdater>(tmpdir));
 #endif
+#ifdef INTEL_C62X_SUPPORT
+    updaters.emplace_back(std::make_unique<BIOSUpdater>(tmpdir));
+#endif
 #ifdef OBMC_PHOSPHOR_IMAGE
     updaters.emplace_back(std::make_unique<OBMCPhosphorImageUpdater>(tmpdir));
 #endif
 #ifdef INTEL_PLATFORMS
-    updaters.emplace_back(std::make_unique<BIOSUpdater>(tmpdir));
     updaters.emplace_back(std::make_unique<IntelPlatformsUpdater>(tmpdir));
 #endif
 }

--- a/src/image_intel.cpp
+++ b/src/image_intel.cpp
@@ -195,7 +195,10 @@ void IntelPlatformsUpdater::reset()
 
     Tracer tracer("Clear writable partitions");
     std::ignore = exec(FLASH_ERASE_CMD " /dev/mtd/rwfs 0 0");
-    std::ignore = exec(FLASH_ERASE_CMD " /dev/mtd/sofs 0 0");
+    // NOTE: `sofs` should not be erased during the factory reset as it may
+    //       contain the FRU data. On the systems with hardware EEPROM this
+    //       partition typically empty.
+    // std::ignore = exec(FLASH_ERASE_CMD " /dev/mtd/sofs 0 0");
     std::ignore = exec(FLASH_ERASE_CMD " /dev/mtd/u-boot-env 0 0");
 
     if (bootpart == BootPart::image_b)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@
 #include "subprocess.hpp"
 #include "tracer.hpp"
 
-#ifdef INTEL_PLATFORMS
+#ifdef INTEL_C62X_SUPPORT
 #include "image_bios.hpp"
 #endif
 
@@ -218,7 +218,7 @@ static void printUsage(const char* app)
   -y, --yes         don't ask user for confirmation
   -v, --version     print installed firmware version info and exit
 )");
-#ifdef INTEL_PLATFORMS
+#ifdef INTEL_C62X_SUPPORT
     printf(R"(  -g, --gbe         write 10GBE region only
   -n, --nvread FILE  read NVRAM to file
   -w, --nvwrite FILE write NVRAM from file
@@ -252,7 +252,7 @@ int main(int argc, char* argv[])
         { "force",   no_argument,       0, 'F' },
         { "yes",     no_argument,       0, 'y' },
         { "version", no_argument,       0, 'v' },
-#ifdef INTEL_PLATFORMS
+#ifdef INTEL_C62X_SUPPORT
         { "gbe",     no_argument,       0, 'g' },
         { "nvread",  required_argument, 0, 'n' },
         { "nvwrite", required_argument, 0, 'w' },
@@ -268,7 +268,7 @@ int main(int argc, char* argv[])
     bool forceFlash = false;
     bool doShowVersion = false;
     std::string firmwareFile;
-#ifdef INTEL_PLATFORMS
+#ifdef INTEL_C62X_SUPPORT
     std::string nvramReadFile;
     std::string nvramWriteFile;
 #endif
@@ -277,7 +277,7 @@ int main(int argc, char* argv[])
     int optVal;
     while ((optVal = getopt_long(argc, argv,
                                  "hf:rsmFyv"
-#ifdef INTEL_PLATFORMS
+#ifdef INTEL_C62X_SUPPORT
                                  "gn:w:"
 #endif
                                  ,
@@ -317,7 +317,7 @@ int main(int argc, char* argv[])
                 doShowVersion = true;
                 break;
 
-#ifdef INTEL_PLATFORMS
+#ifdef INTEL_C62X_SUPPORT
             case 'g':
                 BIOSUpdater::writeGbeOnly = true;
                 break;
@@ -352,7 +352,7 @@ int main(int argc, char* argv[])
         {
             resetFirmware(interactive, forceFlash);
         }
-#ifdef INTEL_PLATFORMS
+#ifdef INTEL_C62X_SUPPORT
         else if (!nvramReadFile.empty())
         {
             BIOSUpdater::readNvram(nvramReadFile);
@@ -365,7 +365,7 @@ int main(int argc, char* argv[])
         else
         {
             fprintf(stderr, "One or both of --file/--reset "
-#ifdef INTEL_PLATFORMS
+#ifdef INTEL_C62X_SUPPORT
                             "or one of --nvread/-nvwrite "
 #endif
                             "options must be specified!\n");


### PR DESCRIPTION
Our new platform `YADRO-X2-200` has no access to the UEFI flash drive.
Functionality for its reflashing should be disabled for the such
machines.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>