### PR TITLE
Block update procedure while host is powered on

### DIFF
--- a/src/image_intel.cpp
+++ b/src/image_intel.cpp
@@ -205,6 +205,14 @@ void IntelPlatformsUpdater::reset()
     tracer.done();
 }
 
+void IntelPlatformsUpdater::lock()
+{
+    if (isChassisOn())
+    {
+        throw FwupdateError("The host is running now, operation cancelled!");
+    }
+}
+
 void IntelPlatformsUpdater::doInstall(const fs::path& file)
 {
     BootPart bootpart = BootPart::unknown;

--- a/src/image_intel.hpp
+++ b/src/image_intel.hpp
@@ -13,6 +13,7 @@ struct IntelPlatformsUpdater : public FwUpdBase
     using FwUpdBase::FwUpdBase;
 
     void reset() override;
+    void lock() override;
     void doInstall(const fs::path& file) override;
     bool doAfterInstall(bool reset) override;
     bool isFileFlashable(const fs::path& file) const override;


### PR DESCRIPTION
Currently, when trying to update BIOS, and the host is powered on,
a warning message is displayed and the procedure is aborted.
However, when trying to update BMC the procedure starts.
This commit prohibits updating BMC when the host is powered on
(as in WebUI).

Signed-off-by: Vladimir Kuznetsov <v.kuznetsov@yadro.com>