### PR TITLE
x722: assert ResetMAC property

### DIFF
--- a/src/dbus.hpp
+++ b/src/dbus.hpp
@@ -104,6 +104,34 @@ PropertyType getProperty(const BusName& busname, const Path& path,
 }
 
 /**
+ * @brief Set D-Bus property
+ *
+ * @param busname  - D-Bus service name
+ * @param path     - Object path
+ * @param iface    - Property interface
+ * @param property - Property name
+ * @param value    - Property value
+ */
+template <typename PropertyType>
+void setProperty(const BusName& busname, const Path& path,
+                 const Interface& iface, const PropertyName& property,
+                 const PropertyType& value)
+{
+    auto req = systemBus.new_method_call(busname.c_str(), path.c_str(),
+                                         SYSTEMD_PROPERTIES_INTERFACE, "Set");
+    req.append(iface, property, std::variant<PropertyType>(value));
+
+    try
+    {
+        systemBus.call_noreply(req);
+    }
+    catch (const sdbusplus::exception::SdBusError& e)
+    {
+        throw FwupdateError("Set property call failed: %s", e.what());
+    }
+}
+
+/**
  * @brief Check whether the host is running
  *
  * @return - true if the Chassis is powered on

--- a/src/image_bios.cpp
+++ b/src/image_bios.cpp
@@ -610,6 +610,30 @@ void BIOSUpdater::resetX722MacAddrs()
 
             flashGbe(dumpFile, mtdDevice);
 
+            {
+                static constexpr auto resetMacPath =
+                    "/xyz/openbmc_project/control/host0/boot/one_time";
+                static constexpr auto resetMacIface =
+                    "xyz.openbmc_project.Control.Boot.ResetMAC";
+
+                Tracer tracer("Set ResetMAC flag");
+
+                auto objects = getObjects(resetMacPath, {resetMacIface});
+                if (!objects.empty())
+                {
+                    setProperty(objects.begin()->first, resetMacPath,
+                                resetMacIface, "ResetMAC", true);
+                }
+                else
+                {
+                    tracer.fail();
+                    printf("WARNING: No service providing `ResetMAC` property "
+                           "found!\n");
+                }
+
+                tracer.done();
+            }
+
             upd.unlock();
         }
         else


### PR DESCRIPTION
This brings support for `ResetMAC` property, that will be asserted during resetting x722 MAC addresses.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>