### PR TITLE
image_intel: add golden flash support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,8 @@ if reboot_guard_support
     conf.set_quoted('REBOOT_GUARD_DISABLE', get_option('reboot-guard-disable'))
 endif
 
+conf.set('GOLDEN_FLASH_SUPPORT', get_option('golden-flash-support'))
+
 host_image_type = get_option('host-image-type')
 if host_image_type == 'openpower'
     conf.set('OPENPOWER_SUPPORT', true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -40,6 +40,8 @@ option('host-image-type', type: 'combo',
        description: 'The Host firmware image type')
 option('intel-x722-support', type: 'boolean', value: false,
        description: 'Enable support for Intel X722 Network Adapter')
+option('golden-flash-support', type: 'boolean', value: false,
+       description: 'Enable support for alternate flash chip')
 
 option('chassis-state-path', type: 'string',
        value: '/xyz/openbmc_project/state/chassis0',

--- a/src/image_bios.hpp
+++ b/src/image_bios.hpp
@@ -34,5 +34,8 @@ struct BIOSUpdater : public FwUpdBase
     bool locked = false;
     gpiod::line gpioPCHPower;
     gpiod::line gpioBIOSSel;
+#ifdef GOLDEN_FLASH_SUPPORT
+    gpiod::line gpioActiveFlashSel;
+#endif // GOLDEN_FLASH_SUPPORT
     int pca9698FD = -1;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,10 @@
 
 namespace fs = std::filesystem;
 
+#ifdef GOLDEN_FLASH_SUPPORT
+bool useGoldenFlash = false;
+#endif // GOLDEN_FLASH_SUPPORT
+
 /**
  * @brief Prints version details of all active software objects.
  */
@@ -218,6 +222,10 @@ static void printUsage(const char* app)
   -y, --yes         don't ask user for confirmation
   -v, --version     print installed firmware version info and exit
 )");
+#ifdef GOLDEN_FLASH_SUPPORT
+    printf("  -a, --alt-mtd     operate on the alternate flash chip "
+           "(aka golden flash)\n");
+#endif // GOLDEN_FLASH_SUPPORT
 #ifdef INTEL_C62X_SUPPORT
 #ifdef INTEL_X722_SUPPORT
     printf(R"(  -g, --gbe         write 10GBE region only
@@ -257,6 +265,9 @@ int main(int argc, char* argv[])
         { "force",   no_argument,       0, 'F' },
         { "yes",     no_argument,       0, 'y' },
         { "version", no_argument,       0, 'v' },
+#ifdef GOLDEN_FLASH_SUPPORT
+        { "alt-mtd", no_argument,       0, 'a' },
+#endif // GOLDEN_FLASH_SUPPORT
 #ifdef INTEL_C62X_SUPPORT
 #ifdef INTEL_X722_SUPPORT
         { "gbe",     no_argument,       0, 'g' },
@@ -289,6 +300,9 @@ int main(int argc, char* argv[])
     int optVal;
     while ((optVal = getopt_long(argc, argv,
                                  "hf:rsmFyv"
+#ifdef GOLDEN_FLASH_SUPPORT
+                                 "a"
+#endif // GOLDEN_FLASH_SUPPORT
 #ifdef INTEL_C62X_SUPPORT
 #ifdef INTEL_X722_SUPPORT
                                  "gR"
@@ -331,6 +345,12 @@ int main(int argc, char* argv[])
             case 'v':
                 doShowVersion = true;
                 break;
+
+#ifdef GOLDEN_FLASH_SUPPORT
+            case 'a':
+                useGoldenFlash = true;
+                break;
+#endif // GOLDEN_FLASH_SUPPORT
 
 #ifdef INTEL_C62X_SUPPORT
 #ifdef INTEL_X722_SUPPORT


### PR DESCRIPTION
This brings an optional support for alternative flash drive on intel-c62x based platforms.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>