### PR TITLE
Fix host MAC resetting without x722 support

### DIFF
--- a/src/image_bios.cpp
+++ b/src/image_bios.cpp
@@ -611,9 +611,8 @@ void BIOSUpdater::writeNvram(const std::string& file)
     }
 }
 
-void BIOSUpdater::resetX722MacAddrs()
+void BIOSUpdater::resetHostMacAddrs()
 {
-#ifdef INTEL_X722_SUPPORT
     BIOSUpdater upd(fs::temp_directory_path());
     upd.files.push_back("dummy");
 
@@ -644,6 +643,7 @@ void BIOSUpdater::resetX722MacAddrs()
             tracer.done();
         }
 
+#ifdef INTEL_X722_SUPPORT
         auto fruMacAddrs = NvmX722::getMacFromFRU();
         if (count(fruMacAddrs) > 0)
         {
@@ -676,6 +676,7 @@ void BIOSUpdater::resetX722MacAddrs()
         {
             printf("WARNING: No x722 MAC addresses found in FRU!\n");
         }
+#endif // INTEL_X722_SUPPORT
     }
     catch (...)
     {
@@ -689,5 +690,4 @@ void BIOSUpdater::resetX722MacAddrs()
         }
         throw;
     }
-#endif // INTEL_X722_SUPPORT
 }

--- a/src/image_bios.hpp
+++ b/src/image_bios.hpp
@@ -28,7 +28,7 @@ struct BIOSUpdater : public FwUpdBase
     static bool writeGbeOnly;
     static void readNvram(const std::string& file);
     static void writeNvram(const std::string& file);
-    static void resetX722MacAddrs();
+    static void resetHostMacAddrs();
 
   private:
     bool locked = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,12 +228,11 @@ static void printUsage(const char* app)
 #endif // GOLDEN_FLASH_SUPPORT
 #ifdef INTEL_C62X_SUPPORT
 #ifdef INTEL_X722_SUPPORT
-    printf(R"(  -g, --gbe         write 10GBE region only
-  -R, --reset-x722-mac-addresses
-                    replace x722 MAC addresses with values from FRU
-)");
+    printf("  -g, --gbe         write 10GBE region only\n");
 #endif // INTEL_X722_SUPPORT
-    printf(R"(  -n, --nvread FILE  read NVRAM to file
+    printf(R"(  -R, --reset-host-mac-addresses
+                     replace host MAC addresses with values from FRU
+  -n, --nvread FILE  read NVRAM to file
   -w, --nvwrite FILE write NVRAM from file
 )");
 #endif // INTEL_C62X_SUPPORT
@@ -271,9 +270,9 @@ int main(int argc, char* argv[])
 #ifdef INTEL_C62X_SUPPORT
 #ifdef INTEL_X722_SUPPORT
         { "gbe",     no_argument,       0, 'g' },
-        { "reset-x722-mac-addresses",
-                     no_argument,       0, 'R' },
 #endif // INTEL_X722_SUPPORT
+        { "reset-host-mac-addresses",
+                     no_argument,       0, 'R' },
         { "nvread",  required_argument, 0, 'n' },
         { "nvwrite", required_argument, 0, 'w' },
 #endif // INTEL_C62X_SUPPORT
@@ -289,9 +288,7 @@ int main(int argc, char* argv[])
     bool doShowVersion = false;
     std::string firmwareFile;
 #ifdef INTEL_C62X_SUPPORT
-#ifdef INTEL_X722_SUPPORT
-    bool doResetX722MacAddrs = false;
-#endif // INTEL_X722_SUPPORT
+    bool doResetHostMacAddrs = false;
     std::string nvramReadFile;
     std::string nvramWriteFile;
 #endif
@@ -305,9 +302,9 @@ int main(int argc, char* argv[])
 #endif // GOLDEN_FLASH_SUPPORT
 #ifdef INTEL_C62X_SUPPORT
 #ifdef INTEL_X722_SUPPORT
-                                 "gR"
+                                 "g"
 #endif // INTEL_X722_SUPPORT
-                                 "n:w:"
+                                 "Rn:w:"
 #endif // INTEL_C62X_SUPPORT
                                  ,
                                  opts, nullptr)) != -1)
@@ -357,11 +354,12 @@ int main(int argc, char* argv[])
             case 'g':
                 BIOSUpdater::writeGbeOnly = true;
                 break;
+#endif // INTEL_X722_SUPPORT
 
             case 'R':
-                doResetX722MacAddrs = true;
+                doResetHostMacAddrs = true;
                 break;
-#endif // INTEL_X722_SUPPORT
+
             case 'n':
                 nvramReadFile = optarg;
                 break;
@@ -393,12 +391,10 @@ int main(int argc, char* argv[])
             resetFirmware(interactive, forceFlash);
         }
 #ifdef INTEL_C62X_SUPPORT
-#ifdef INTEL_X722_SUPPORT
-        else if (doResetX722MacAddrs)
+        else if (doResetHostMacAddrs)
         {
-            BIOSUpdater::resetX722MacAddrs();
+            BIOSUpdater::resetHostMacAddrs();
         }
-#endif // INTEL_X722_SUPPORT
         else if (!nvramReadFile.empty())
         {
             BIOSUpdater::readNvram(nvramReadFile);


### PR DESCRIPTION
This refixes b03c33c44c44bb8d4726aee6d633a35778d72498 and makes host MAC addresses resetting working properly with disabled x722 support.

Signed-off-by: Alexander Filippov <a.filippov@yadro.com>